### PR TITLE
Parsing multiple key value pairs from setting strings

### DIFF
--- a/gdm3setup.py
+++ b/gdm3setup.py
@@ -663,8 +663,8 @@ class MainWindow(Gtk.Window) :
 def get_setting(name,data):
 	for line in data:
 		line = unicode(line)
-		if line[0:len(name)+1]==name+"=":
-			value = line[len(name)+1:len(line)].strip()
+		if -1 != line.find(name+"="):
+			value = line[line.rfind("=")+1:len(line)].strip()
 			break
 	return value
 


### PR DESCRIPTION
Hi, I'm not sure if just my configuration is screwed but gdm3setup.py failed to start because
I had something like "SHELL_LOGO=USER_LIST=false" inside my setting string.

This was however not parsed the way needed. I just changed the get_setting function to return the value
just after the last '=' and only checking if 'name=' is at least somewhere in the string.
