### PR TITLE
Handle multiple setting assignment on same line

### DIFF
--- a/gdm3setup.py
+++ b/gdm3setup.py
@@ -703,10 +703,12 @@ class MainWindow(Gtk.Window) :
 def get_setting(name,data):
 	for line in data:
 		line = unicode(line)
-		if line[0:len(name)+1]==name+"=":
-			value = line[len(name)+1:len(line)].strip()
-			break
-	return value
+		# "=" can be in value so find last "=" before first "'"
+		value = line[0:line.rindex("=", 0, line.find("'"))]
+		names = line[0:len(value)].split("=")
+		if name in names:
+			return value
+	return None
 
 def unquote(value):
 	if value[0:1] == "'"  and value[len(value)-1:len(value)] == "'" :


### PR DESCRIPTION
Hi!

I ran into the same problem others at AUR are having at
https://aur.archlinux.org/packages.php?ID=50232, that gives the following stack trace.

```
Traceback (most recent call last):
File "/usr/bin/gdm3setup.py", line 737, in <module>
    MainWindow().show()
File "/usr/bin/gdm3setup.py", line 404, in __init__
    self.get_gdm()
File "/usr/bin/gdm3setup.py", line 484, in get_gdm
    self.FALLBACK_LOGO = unquote(get_setting("FALLBACK_LOGO",settings))
File "/usr/bin/gdm3setup.py", line 709, in get_setting
    return value
UnboundLocalError: local variable 'value' referenced before assignment
```

The problem is that multiple settings with the same value can be set on same line.
In this case: LOGO_ICON=FALLBACK_LOGO=''.  I'm guessing you can't reproduce it
yourself so I tried fixing it myself.

I'm new to GitHub but I have been wanting to try it out for a while now and
this seemed like a nice opportunity.  Please don't hesitate to tell me if I did
something wrong.
