### PR TITLE
Align translation infrastructure more with intltool

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,0 +1,8 @@
+# keep this file sorted alphabetically, one language code per line
+de_DE
+es_ES
+fr
+it
+pt_BR
+zh_CN
+zh_TW

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,0 +1,4 @@
+# List of source files containing translatable strings.
+
+[type: gettext/glade]app-menu.ui
+[type: gettext/glade]gdm3setup.ui

--- a/po/README.md
+++ b/po/README.md
@@ -1,0 +1,17 @@
+# Generating up-to-date PO files for translation
+
+## 1. Generate an up-to-date POT template
+
+To create an up-to-date PO template file (.pot) from the current source:
+
+$ intltool-update --pot -g gdm3setup
+
+## 2. Update all PO files with latest translatable strings
+
+$ intltool-update -r -g gdm3setup
+
+It uses the template file for referene. Existing translations are kept, of course.
+
+# Adding a new language
+
+Insert the language code into the LINGUAS file and update the PO files as described above.

--- a/po/gdm3setup-de_DE.po
+++ b/po/gdm3setup-de_DE.po
@@ -9,143 +9,227 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: gdm3setup\n"
-"Report-Msgid-Bugs-To: https://github.com/Nano77/gdm3setup/issues\n"
-"POT-Creation-Date: 2011-12-22 19:35+0100\n"
-"PO-Revision-Date: 2011-12-22 21:50+0100\n"
-"Last-Translator: Stefan Kirrmann <stefan.kirrmann@gmail.com>\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2019-03-31 00:58+0100\n"
+"PO-Revision-Date: 2019-03-31 01:03+0100\n"
+"Last-Translator: Christian Kirbach <christian.kirbach@gmail.com>\n"
 "Language-Team: \n"
 "Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 2.2.1\n"
 
-#: gdm3setup.ui:22
-#: gdm3setup.ui:272
-msgid "_Cancel"
-msgstr "_Abbrechen"
-
-#: gdm3setup.ui:37
-#: gdm3setup.ui:287
-msgid "_Apply"
-msgstr "An_wenden"
-
-#: gdm3setup.py:22
-msgid "(None)"
-msgstr "(Keine)"
-
-#: gdm3setup.in.py:132
-msgid "_Remove"
-msgstr "_Entfernen"
-
-#: gdm3setup.in.py:133
-msgid "_Open"
-msgstr "Ö_ffnen"
-
-#: gdm3setup.py:47
-msgid "Select a file"
-msgstr "Datei auswählen"
-
-#: gdm3setup.py:97
-msgid "Disabled"
-msgstr "Deaktiviert"
-
-#: gdm3setup.py:187
-#: gdm3setup.py:332
-msgid "Automatic login"
-msgstr "Automatische Anmeldung"
-
-#: gdm3setup.py:192
-msgid "Enable automatic login"
-msgstr "Automatische Anmeldung aktivieren"
-
-#: gdm3setup.py:200
-msgid "User Name"
-msgstr "Benutzername"
-
-#: gdm3setup.py:212
-msgid "Enable delay before automatic login"
-msgstr "Verzögerung vor automatischer Anmeldung"
-
-#: gdm3setup.py:224
-msgid "Apply"
-msgstr "Anwenden"
-
-#: gdm3setup.py:272
-msgid "Login screen settings"
-msgstr "Einstellungen für GDM3"
-
-#: gdm3setup.py:282
-msgid "General"
-msgstr "Allgemeine"
-
-#: gdm3setup.py:317
-msgid "Wallpaper"
-msgstr "Hintergrund"
-
-#: gdm3setup.py:322
-msgid "Icon theme"
-msgstr "Symbolthema"
-
-#: gdm3setup.py:327
-msgid "Cursor theme"
-msgstr "Cursor-Thema"
-
-#: gdm3setup.py:338
-msgid "Shell theme"
-msgstr "Shell-Thema"
-
-#: gdm3setup.py:343
-msgid "Shell Logo"
-msgstr "Shell-Logo"
-
-#: gdm3setup.py:348
-msgid "Show Date in Clock"
-msgstr "Uhrzeit mit Datum"
-
-#: gdm3setup.py:353
-msgid "Show Seconds in Clock"
-msgstr "Uhrzeit mit Sekunden"
-
-#: gdm3setup.py:359
-msgid "GTK3 theme"
-msgstr "GTK3-Thema"
-
-#: gdm3setup.py:364
-msgid "Font"
-msgstr "Schriftart"
-
-#: gdm3setup.py:369
-msgid "Logo Icon"
-msgstr "Logo-Symbol"
-
-#: gdm3setup.py:374
-msgid "Enable Banner"
-msgstr "Banner aktivieren"
-
-#: gdm3setup.py:381
-msgid "Disable User List"
-msgstr "Benutzerliste deaktivieren"
-
-#: gdm3setup.py:385
-msgid "Disable Restart Buttons"
-msgstr "Neustart-Knopf deaktivieren"
-
-#: gdm3setup.py:413
-msgid "Select Wallpaper"
-msgstr "Hintergrund auswählen"
-
-#: gdm3setup.in
+#: ../app-menu.ui.h:1
 msgid "_About"
 msgstr "_Info"
 
-#: gdm3setup.in
+#: ../app-menu.ui.h:2
 msgid "_Quit"
 msgstr "_Beenden"
 
-msgid "translator-credits"
-msgstr ""
-"NanoArch <nanoarch77@gmail.com>\n"
-"Mario Blättermann <mario.blaettermann@gmail.com>\n"
-"Stefan Kirrmann <stefan.kirrmann@gmail.com>"
+#: ../gdm3setup.ui.h:1
+msgid "Automatic login"
+msgstr "Automatische Anmeldung"
 
+#: ../gdm3setup.ui.h:2
+msgid "_Cancel"
+msgstr "_Abbrechen"
+
+#: ../gdm3setup.ui.h:3
+msgid "_Apply"
+msgstr "An_wenden"
+
+#: ../gdm3setup.ui.h:4
+msgid "Login mode"
+msgstr "Anmeldemodus"
+
+#: ../gdm3setup.ui.h:5
+msgid "Manual"
+msgstr "Manuell"
+
+#: ../gdm3setup.ui.h:6
+msgid "Automatic"
+msgstr "Automatisch"
+
+#: ../gdm3setup.ui.h:7
+msgid "Automatic after a delay"
+msgstr "Automatisch nach Verzögerung"
+
+#: ../gdm3setup.ui.h:8
+msgid "Select an user"
+msgstr "Wählen Sie ein Benutzerkonto"
+
+#: ../gdm3setup.ui.h:9
+msgid "Select the delay before automatic login"
+msgstr "Legen Sie die Verzögerung für die Anmeldung fest"
+
+#: ../gdm3setup.ui.h:10
+msgid "Banner"
+msgstr "Banner"
+
+#: ../gdm3setup.ui.h:11
+msgid "Enable Banner"
+msgstr "Banner aktivieren"
+
+#: ../gdm3setup.ui.h:12
+msgid "Shell theme"
+msgstr "Shell-Thema"
+
+#: ../gdm3setup.ui.h:13
+msgid "Adwaita"
+msgstr "Adwaita"
+
+#: ../gdm3setup.ui.h:14
+msgid "Icon theme"
+msgstr "Symbolthema"
+
+#: ../gdm3setup.ui.h:15
+msgid "gnome"
+msgstr "gnome"
+
+#: ../gdm3setup.ui.h:16
+msgid "Cursor theme"
+msgstr "Mauszeigerthema"
+
+#: ../gdm3setup.ui.h:17
+msgid "(None)"
+msgstr "(Keines)"
+
+#: ../gdm3setup.ui.h:18
+msgid ""
+"Bad path :\n"
+"File must be in /usr/share or /usr/local/share"
+msgstr ""
+"Ungültiger Pfad :\n"
+"Die Datei muss im Ordner /usr/share or /usr/local/share sein"
+
+#: ../gdm3setup.ui.h:20
+msgid "Shell Logo"
+msgstr "Shell-Logo"
+
+#: ../gdm3setup.ui.h:21
+msgid "Disabled"
+msgstr "Deaktiviert"
+
+#: ../gdm3setup.ui.h:22
+msgid "Authentication methods"
+msgstr "Legitimierungsmethoden"
+
+#: ../gdm3setup.ui.h:23
+msgid "All"
+msgstr "Alle"
+
+#: ../gdm3setup.ui.h:24
+msgid "Allowed failures"
+msgstr "Erlaubte Fehlanmeldungen"
+
+#: ../gdm3setup.ui.h:25
+msgid "0"
+msgstr "0"
+
+#: ../gdm3setup.ui.h:26
+msgid "Disable User List"
+msgstr "Benutzerliste deaktivieren"
+
+#: ../gdm3setup.ui.h:27
+msgid "Hide the Power Off button"
+msgstr "Den Ausschalteknopf verbergen"
+
+#: ../gdm3setup.ui.h:28
+msgid "Show Date in Clock"
+msgstr "Uhrzeit mit Datum"
+
+#: ../gdm3setup.ui.h:29
+msgid "Show Seconds in Clock"
+msgstr "Uhrzeit mit Sekunden"
+
+#: ../gdm3setup.ui.h:30
+msgid "Enable Wayland"
+msgstr "Wayland aktivieren"
+
+#: ../gdm3setup.ui.h:31
+msgid "1"
+msgstr "1"
+
+#: ../gdm3setup.ui.h:32
+msgid "2"
+msgstr "2"
+
+#: ../gdm3setup.ui.h:33
+msgid "3"
+msgstr "3"
+
+#: ../gdm3setup.ui.h:34
+msgid "4"
+msgstr "4"
+
+#: ../gdm3setup.ui.h:35
+msgid "5"
+msgstr "5"
+
+#: ../gdm3setup.ui.h:36
+msgid "6"
+msgstr "6"
+
+#: ../gdm3setup.ui.h:37
+msgid "7"
+msgstr "7"
+
+#: ../gdm3setup.ui.h:38
+msgid "Fingerprint"
+msgstr "Fingerabdruck"
+
+#: ../gdm3setup.ui.h:39
+msgid "Password"
+msgstr "Passwort"
+
+#: ../gdm3setup.ui.h:40
+msgid "Smartcard"
+msgstr "Chipkarte"
+
+#~ msgid "_Remove"
+#~ msgstr "_Entfernen"
+
+#~ msgid "_Open"
+#~ msgstr "Ö_ffnen"
+
+#~ msgid "Enable automatic login"
+#~ msgstr "Automatische Anmeldung aktivieren"
+
+#~ msgid "User Name"
+#~ msgstr "Benutzername"
+
+#~ msgid "Apply"
+#~ msgstr "Anwenden"
+
+#~ msgid "Login screen settings"
+#~ msgstr "Einstellungen für GDM3"
+
+#~ msgid "General"
+#~ msgstr "Allgemeine"
+
+#~ msgid "Wallpaper"
+#~ msgstr "Hintergrund"
+
+#~ msgid "GTK3 theme"
+#~ msgstr "GTK3-Thema"
+
+#~ msgid "Font"
+#~ msgstr "Schriftart"
+
+#~ msgid "Logo Icon"
+#~ msgstr "Logo-Symbol"
+
+#~ msgid "Disable Restart Buttons"
+#~ msgstr "Neustart-Knopf deaktivieren"
+
+#~ msgid "Select Wallpaper"
+#~ msgstr "Hintergrund auswählen"
+
+#~ msgid "translator-credits"
+#~ msgstr ""
+#~ "NanoArch <nanoarch77@gmail.com>\n"
+#~ "Mario Blättermann <mario.blaettermann@gmail.com>\n"
+#~ "Stefan Kirrmann <stefan.kirrmann@gmail.com>"

--- a/po/makefile
+++ b/po/makefile
@@ -1,17 +1,14 @@
 
-LOCALS := fr es_ES de_DE it pt_BR zh_CN zh_TW
-all:
-	@for local in $(LOCALS); do \
-        	mkdir -p locale/$$local/LC_MESSAGES/; \
-	done
+LOCALES := $(shell tail -n +2 LINGUAS )
 
-	msgfmt gdm3setup-fr.po -o locale/fr/LC_MESSAGES/gdm3setup.mo
-	msgfmt gdm3setup-es_ES.po -o locale/es_ES/LC_MESSAGES/gdm3setup.mo
-	msgfmt gdm3setup-de_DE.po -o locale/de_DE/LC_MESSAGES/gdm3setup.mo
-	msgfmt gdm3setup-it.po -o locale/it/LC_MESSAGES/gdm3setup.mo
-	msgfmt gdm3setup-pt_BR.po -o locale/pt_BR/LC_MESSAGES/gdm3setup.mo
-	msgfmt gdm3setup-zh_CN.po -o locale/zh_CN/LC_MESSAGES/gdm3setup.mo
-	msgfmt gdm3setup-zh_TW.po -o locale/zh_TW/LC_MESSAGES/gdm3setup.mo
+all:
+	intltool-update --pot -g gdm3setup
+	intltool-update -r -g gdm3setup
+
+	@for locale in $(LOCALES); do \
+        	mkdir -p locale/$$locale/LC_MESSAGES/; \
+        	msgfmt gdm3setup-$$locale.po -o locale/$$locale/LC_MESSAGES/gdm3setup.mo; \
+	done
 
 clean:
 	rm -r locale
@@ -20,7 +17,10 @@ install:
 	cp -r locale $(DESTDIR)/usr/share/
 
 uninstall:
-	rm $(DESTDIR)/usr/share/locale/{de_DE,es_ES,fr,it,pt_BR,zh_CN,zh_TW}/LC_MESSAGES/gdm3setup.mo
+	@for locale in $(LOCALES); do \
+        	rm $(DESTDIR)/usr/share/locale/$$locale/LC_MESSAGES/gdm3setup.mo; \
+	done
+
 
 
 


### PR DESCRIPTION
Add LINGUAS and POTFILES.in files so that translations can be updated easier with new messages from source files.
Add README.md that briefly describes how to use intltool.
Update makefile to make use of the contents of LIGUAS. Adding and removing languages is done now by editing the LINGUAS file.